### PR TITLE
fix: allow `onError` for my object exceptions

### DIFF
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -214,7 +214,7 @@ export class Hono<
         }
         return this.notFoundHandler(c)
       } catch (err) {
-        if (err instanceof Error) {
+        if (err instanceof Error || typeof err === 'object') {
           return this.errorHandler(err, c)
         }
         throw err

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -234,7 +234,7 @@ export class Hono<
         )
       }
     } catch (err) {
-      if (err instanceof Error) {
+      if (err instanceof Error || typeof err === 'object') {
         return this.errorHandler(err, c)
       }
       throw err


### PR DESCRIPTION
In my implementation, I'm throwing objects and want to use the onError handler